### PR TITLE
Error on rendering sortable column

### DIFF
--- a/src/components/BaseColumn.php
+++ b/src/components/BaseColumn.php
@@ -450,14 +450,11 @@ abstract class BaseColumn extends Object
     }
 
     /**
-     * @param $name
-     * @param $value
-     * @param $options
      * @return string
      */
-    protected function renderDragColumn($name, $options)
+    protected function renderDragColumn()
     {
-        return Html::tag('span', $value, ['class' => 'glyphicon glyphicon-menu-hamburger drag-handle']);
+        return Html::tag('span', $null, ['class' => 'glyphicon glyphicon-menu-hamburger drag-handle']);
     }
 
     /**


### PR DESCRIPTION
The renderDragColumn function uses an undefined variable $value, and declares an unused param called $options, but issues are fixed.